### PR TITLE
BUG cannot have direct git dependence for pypi

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ readme = "README.md"
 
 [project.optional-dependencies]
 oci = [
-  "conda-oci-mirror@git+https://github.com/channel-mirrors/conda-oci-mirror.git@v0.1.0#egg=conda-oci-mirror"
+  "conda-oci-mirror"
 ]
 
 [project.urls]


### PR DESCRIPTION
pypi choked on this so listing a package that does not exist for now.