### PR TITLE
OCI artifact metadata: handle missing keys gracefully

### DIFF
--- a/conda_forge_metadata/oci.py
+++ b/conda_forge_metadata/oci.py
@@ -26,7 +26,7 @@ def _extract_read(infotar: tarfile.TarFile, *names: str, **kwargs) -> str:
     default: Any
         The default value to return if none of the names are found.
     """
-    names_in_tar = infotar.getnames()
+    names_in_tar = set(infotar.getnames())
     for name in names:
         if name in names_in_tar:
             file = infotar.extractfile(name)

--- a/conda_forge_metadata/oci.py
+++ b/conda_forge_metadata/oci.py
@@ -108,24 +108,25 @@ def get_oci_artifact_data(
         "name": index.get("name", ""),
         "version": index.get("version", ""),
         "index": index,
-        "about": json.loads(_extract_read(infotar, "about.json")),
+        "about": json.loads(_extract_read(infotar, "about.json") or "{}"),
         "rendered_recipe": YAML.load(
-            _extract_read(infotar, "recipe/meta.yaml", "meta.yaml")
+            _extract_read(infotar, "recipe/meta.yaml", "meta.yaml") or "{}"
         ),
-        "raw_recipe": _extract_read(
-            infotar,
-            "recipe/meta.yaml.template",
-            "recipe/meta.yaml",
-            "meta.yaml",
+        "raw_recipe": (
+            _extract_read(
+                infotar,
+                "recipe/meta.yaml.template",
+                "recipe/meta.yaml",
+                "meta.yaml",
+            )
+            or ""
         ),
         "conda_build_config": (
-            YAML.load(_extract_read(infotar, "recipe/conda_build_config.yaml"))
-            if "recipe/conda_build_config.yaml" in infotar.getnames()
-            else {}
+            YAML.load(_extract_read(infotar, "recipe/conda_build_config.yaml") or "{}")
         ),
         "files": [
             f
-            for f in _extract_read(infotar, "files").splitlines()
+            for f in (_extract_read(infotar, "files") or "").splitlines()
             if not f.lower().endswith((".pyc", ".txt"))
         ],
     }

--- a/conda_forge_metadata/oci.py
+++ b/conda_forge_metadata/oci.py
@@ -12,7 +12,7 @@ from conda_forge_metadata.types import ArtifactData
 logger = getLogger(__name__)
 
 
-def _extract_read(infotar: tarfile.TarFile, *names: str) -> str:
+def _extract_read(infotar: tarfile.TarFile, *names: str, **kwargs) -> str:
     """
     Extract a file from a tarfile and return its contents as a string.
 
@@ -23,6 +23,8 @@ def _extract_read(infotar: tarfile.TarFile, *names: str) -> str:
     names : str
         The different names to try to extract. Only the first one found is
         returned.
+    default: Any
+        The default value to return if none of the names are found.
     """
     names_in_tar = infotar.getnames()
     for name in names:
@@ -31,6 +33,8 @@ def _extract_read(infotar: tarfile.TarFile, *names: str) -> str:
             if file is not None:
                 return file.read().decode()
     else:
+        if "default" in kwargs:
+            return kwargs["default"]
         raise ValueError(f"{names} not in {names_in_tar}")
 
 
@@ -101,32 +105,32 @@ def get_oci_artifact_data(
         return None
 
     YAML = yaml.YAML(typ="safe")
-    index: dict[str, Any] = json.loads(_extract_read(infotar, "index.json"))
+    index: dict[str, Any] = json.loads(
+        _extract_read(infotar, "index.json", default="{}")
+    )
     return {
         # https://github.com/regro/libcflib/blob/062858e90af2795d2eb098034728cace574a51b8/libcflib/harvester.py#L14
         "metadata_version": 1,
         "name": index.get("name", ""),
         "version": index.get("version", ""),
         "index": index,
-        "about": json.loads(_extract_read(infotar, "about.json") or "{}"),
+        "about": json.loads(_extract_read(infotar, "about.json", default="{}")),
         "rendered_recipe": YAML.load(
-            _extract_read(infotar, "recipe/meta.yaml", "meta.yaml") or "{}"
+            _extract_read(infotar, "recipe/meta.yaml", "meta.yaml", default="{}")
         ),
-        "raw_recipe": (
-            _extract_read(
-                infotar,
-                "recipe/meta.yaml.template",
-                "recipe/meta.yaml",
-                "meta.yaml",
-            )
-            or ""
+        "raw_recipe": _extract_read(
+            infotar,
+            "recipe/meta.yaml.template",
+            "recipe/meta.yaml",
+            "meta.yaml",
+            default="",
         ),
-        "conda_build_config": (
-            YAML.load(_extract_read(infotar, "recipe/conda_build_config.yaml") or "{}")
+        "conda_build_config": YAML.load(
+            _extract_read(infotar, "recipe/conda_build_config.yaml", default="{}")
         ),
         "files": [
             f
-            for f in (_extract_read(infotar, "files") or "").splitlines()
+            for f in _extract_read(infotar, "files", default="").splitlines()
             if not f.lower().endswith((".pyc", ".txt"))
         ],
     }


### PR DESCRIPTION
Some keys might not be present in the OCI artifact metadata. e.g. `libgfortran` doesn't have the `about.json` 🤷 

Right now the helper function returns None for those cases, but we were blindly taking that into `json.loads` and `YAML.load`, which errored out with:

```
ValueError: ('about.json',) not in ['files', 'index.json', 'recipe', 'recipe/build.sh', 'recipe/meta.yaml', 'recipe.json']
Traceback:

File "/home/adminuser/venv/lib/python3.9/site-packages/streamlit/runtime/scriptrunner/script_runner.py", line 552, in _run_script
    exec(code, module.__dict__)
File "/mount/src/conda-metadata-app/app.py", line 304, in <module>
    data = get_oci_artifact_data(
File "/home/adminuser/venv/lib/python3.9/site-packages/conda_forge_metadata/oci.py", line 111, in get_oci_artifact_data
    "about": json.loads(_extract_read(infotar, "about.json")),
File "/home/adminuser/venv/lib/python3.9/site-packages/conda_forge_metadata/oci.py", line 34, in _extract_read
    raise ValueError(f"{names} not in {names_in_tar}")
```

or

```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/jrodriguez/devel/conda-metadata-app/.pixi/env/lib/python3.11/site-packages/ruamel/yaml/main.py", line 424, in load
    constructor, parser = self.get_constructor_parser(stream)
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jrodriguez/devel/conda-metadata-app/.pixi/env/lib/python3.11/site-packages/ruamel/yaml/main.py", line 509, in get_constructor_parser
    loader = XLoader(stream)
             ^^^^^^^^^^^^^^^
  File "/Users/jrodriguez/devel/conda-metadata-app/.pixi/env/lib/python3.11/site-packages/ruamel/yaml/main.py", line 502, in __init__
    CParser.__init__(selfx, stream)
  File "_ruamel_yaml.pyx", line 302, in _ruamel_yaml.CParser.__init__
TypeError: a string or stream input is required
```

Now we will build their falsey counterparts (`{}` for dicts, `""` for str).