### PR TITLE
Add `info_json` backend for streamed `.conda` artifacts

### DIFF
--- a/conda_forge_metadata/artifact_info/info_json.py
+++ b/conda_forge_metadata/artifact_info/info_json.py
@@ -1,7 +1,14 @@
 from __future__ import annotations
 
+import json
+import tarfile
+from typing import Any, Generator, Tuple
+
 from conda_forge_metadata.libcfgraph import get_libcfgraph_artifact_data
 from conda_forge_metadata.types import ArtifactData
+from ruamel import yaml
+
+VALID_BACKENDS = ("libcfgraph", "oci", "streamed")
 
 
 def get_artifact_info_as_json(
@@ -45,6 +52,70 @@ def get_artifact_info_as_json(
     elif backend == "oci":
         from conda_forge_metadata.oci import get_oci_artifact_data
 
-        return get_oci_artifact_data(channel, subdir, artifact)
+        tar = get_oci_artifact_data(channel, subdir, artifact)
+        if tar is not None:
+            return info_json_from_tar_generator(tar)
+    elif backend == "streamed":
+        from conda_forge_metadata.streaming import get_streamed_artifact_data
+
+        return info_json_from_tar_generator(
+            get_streamed_artifact_data(channel, subdir, artifact)
+        )
     else:
-        raise ValueError(f"Unknown backend {backend!r}")
+        raise ValueError(
+            f"Unknown backend {backend!r}. Valid backends are {VALID_BACKENDS}."
+        )
+
+
+def info_json_from_tar_generator(
+    tar_tuples: Generator[Tuple[tarfile.TarFile, tarfile.TarInfo], None, None],
+) -> ArtifactData | None:
+    # https://github.com/regro/libcflib/blob/062858e90af/libcflib/harvester.py#L14
+    data = {
+        "metadata_version": 1,
+        "name": "",
+        "version": "",
+        "index": {},
+        "about": {},
+        "rendered_recipe": {},
+        "raw_recipe": "",
+        "conda_build_config": {},
+        "files": [],
+    }
+    YAML = yaml.YAML(typ="safe")
+    for tar, member in tar_tuples:
+        if member.name.endswith("index.json"):
+            index = json.loads(_extract_read(tar, member, default="{}"))
+            data["name"] = index.get("name", "")
+            data["version"] = index.get("version", "")
+            data["index"] = index
+        elif member.name.endswith("about.json"):
+            data["about"] = json.loads(_extract_read(tar, member, default="{}"))
+        elif member.name.endswith("conda_build_config.yaml"):
+            data["conda_build_config"] = YAML.load(
+                _extract_read(tar, member, default="{}")
+            )
+        elif member.name.endswith("files"):
+            data["files"] = [
+                f
+                for f in _extract_read(tar, member, default="").splitlines()
+                if not f.lower().endswith((".pyc", ".txt"))
+            ]
+        elif member.name.endswith("meta.yaml.template"):
+            data["raw_recipe"] = _extract_read(tar, member, default="")
+        elif member.name.endswith("meta.yaml"):
+            recipe = YAML.load(_extract_read(tar, member, default="{}"))
+            data["rendered_recipe"] = recipe
+            if data["raw_recipe"] == "":
+                data["raw_recipe"] = recipe
+    if data["name"] is not None:
+        return data  # type: ignore
+
+
+def _extract_read(
+    tar: tarfile.TarFile, member: tarfile.TarInfo, default: Any = None
+) -> str:
+    f = tar.extractfile(member)
+    if f:
+        return f.read().decode() or default
+    return default

--- a/conda_forge_metadata/artifact_info/info_json.py
+++ b/conda_forge_metadata/artifact_info/info_json.py
@@ -56,6 +56,8 @@ def get_artifact_info_as_json(
         if tar is not None:
             return info_json_from_tar_generator(tar)
     elif backend == "streamed":
+        if artifact.endswith(".tar.bz2"):
+            raise ValueError("streamed backend does not support .tar.bz2 artifacts")
         from conda_forge_metadata.streaming import get_streamed_artifact_data
 
         return info_json_from_tar_generator(

--- a/conda_forge_metadata/streaming.py
+++ b/conda_forge_metadata/streaming.py
@@ -1,0 +1,22 @@
+"""
+Use conda-package-streaming to fetch package metadata
+"""
+from contextlib import closing
+
+from conda_package_streaming.package_streaming import stream_conda_component
+from conda_package_streaming.url import conda_reader_for_url
+
+
+def get_streamed_artifact_data(channel: str, subdir: str, artifact: str):
+    if not channel.startswith("http"):
+        if channel in ("pkgs/main", "pkgs/r", "pkgs/msys2"):
+            channel = f"https//repo.anaconda.com/{channel}"
+        else:
+            channel = f"https://conda.anaconda.org/{channel}"
+
+    # .conda artifacts can be streamed directly from an anaconda.org channel
+    url = f"{channel}/{subdir}/{artifact}"
+    filename, conda = conda_reader_for_url(url)
+
+    with closing(conda):
+        yield from stream_conda_component(filename, conda, component="info")


### PR DESCRIPTION
This is useful when a `.conda` package is OCI mirrored. We only allow it for `.conda` artifacts because `.tar.bz2` files involve downloading the whole thing.