### PR TITLE
fix pre-return check in info_json_from_tar_generator

### DIFF
--- a/conda_forge_metadata/artifact_info/info_json.py
+++ b/conda_forge_metadata/artifact_info/info_json.py
@@ -112,7 +112,7 @@ def info_json_from_tar_generator(
                 data["raw_recipe"] = x
             else:
                 data["rendered_recipe"] = YAML.load(x)
-    if data["name"] is not None:
+    if data["name"]:
         return data  # type: ignore
 
 


### PR DESCRIPTION
Null value is `""` not `None`. Follow-up for #18.