### PR TITLE
allow parsing duplicates keys in YAML

### DIFF
--- a/conda_forge_metadata/artifact_info/info_json.py
+++ b/conda_forge_metadata/artifact_info/info_json.py
@@ -86,6 +86,8 @@ def info_json_from_tar_generator(
         "files": [],
     }
     YAML = yaml.YAML(typ="safe")
+    # some recipes have duplicate keys; e.g. linux-64/clangxx_osx-64-16.0.6-h027b494_6.conda
+    YAML.allow_duplicate_keys = True
     for tar, member in tar_tuples:
         if member.name.endswith("index.json"):
             index = json.loads(_extract_read(tar, member, default="{}"))

--- a/conda_forge_metadata/artifact_info/info_json.py
+++ b/conda_forge_metadata/artifact_info/info_json.py
@@ -86,7 +86,8 @@ def info_json_from_tar_generator(
         "files": [],
     }
     YAML = yaml.YAML(typ="safe")
-    # some recipes have duplicate keys; e.g. linux-64/clangxx_osx-64-16.0.6-h027b494_6.conda
+    # some recipes have duplicate keys; 
+    # e.g. linux-64/clangxx_osx-64-16.0.6-h027b494_6.conda
     YAML.allow_duplicate_keys = True
     for tar, member in tar_tuples:
         if member.name.endswith("index.json"):

--- a/conda_forge_metadata/artifact_info/info_json.py
+++ b/conda_forge_metadata/artifact_info/info_json.py
@@ -86,7 +86,7 @@ def info_json_from_tar_generator(
         "files": [],
     }
     YAML = yaml.YAML(typ="safe")
-    # some recipes have duplicate keys; 
+    # some recipes have duplicate keys;
     # e.g. linux-64/clangxx_osx-64-16.0.6-h027b494_6.conda
     YAML.allow_duplicate_keys = True
     for tar, member in tar_tuples:

--- a/tests/test_info_json.py
+++ b/tests/test_info_json.py
@@ -77,3 +77,14 @@ def test_missing_conda_build_tar_bz2(backend: str):
     )
     assert info is not None
     assert info["conda_build_config"] == {}
+
+
+@pytest.mark.parametrize("backend", info_json.VALID_BACKENDS)
+def test_duplicate_keys_allowed(backend: str):
+    info = info_json.get_artifact_info_as_json(
+        "conda-forge",
+        "linux-64",
+        "clangxx_osx-64-16.0.6-h027b494_6.conda",
+        backend=backend,
+    )
+    assert info is not None


### PR DESCRIPTION
Some packages like https://conda-metadata-app.streamlit.app/?q=conda-forge%2Flinux-64%2Fclangxx_osx-64-16.0.6-h027b494_6.conda have duplicate keys in their conda_build_config metadata (we should probably lint this?)