### PR TITLE
customize which files are skipped from the metadata

### DIFF
--- a/conda_forge_metadata/artifact_info/info_json.py
+++ b/conda_forge_metadata/artifact_info/info_json.py
@@ -13,7 +13,11 @@ VALID_BACKENDS = ("libcfgraph", "oci", "streamed")
 
 
 def get_artifact_info_as_json(
-    channel: str, subdir: str, artifact: str, backend: str = "libcfgraph"
+    channel: str,
+    subdir: str,
+    artifact: str,
+    backend: str = "libcfgraph",
+    skip_files_suffixes: Tuple[str, ...] = (".pyc", ".txt"),
 ) -> ArtifactData | None:
     """Get a blob of artifact data from the conda info directory.
 
@@ -55,14 +59,18 @@ def get_artifact_info_as_json(
 
         tar = get_oci_artifact_data(channel, subdir, artifact)
         if tar is not None:
-            return info_json_from_tar_generator(tar)
+            return info_json_from_tar_generator(
+                tar,
+                skip_files_suffixes=skip_files_suffixes,
+            )
     elif backend == "streamed":
         if artifact.endswith(".tar.bz2"):
             raise ValueError("streamed backend does not support .tar.bz2 artifacts")
         from conda_forge_metadata.streaming import get_streamed_artifact_data
 
         return info_json_from_tar_generator(
-            get_streamed_artifact_data(channel, subdir, artifact)
+            get_streamed_artifact_data(channel, subdir, artifact),
+            skip_files_suffixes=skip_files_suffixes,
         )
     else:
         raise ValueError(
@@ -72,6 +80,7 @@ def get_artifact_info_as_json(
 
 def info_json_from_tar_generator(
     tar_tuples: Generator[Tuple[tarfile.TarFile, tarfile.TarInfo], None, None],
+    skip_files_suffixes: Tuple[str, ...] = (".pyc", ".txt"),
 ) -> ArtifactData | None:
     # https://github.com/regro/libcflib/blob/062858e90af/libcflib/harvester.py#L14
     data = {
@@ -99,11 +108,12 @@ def info_json_from_tar_generator(
                 _extract_read(tar, member, default="{}")
             )
         elif member.name.endswith("files"):
-            data["files"] = [
-                f
-                for f in _extract_read(tar, member, default="").splitlines()
-                if not f.lower().endswith((".pyc", ".txt"))
-            ]
+            files = _extract_read(tar, member, default="").splitlines()
+            if skip_files_suffixes:
+                files = [
+                    f for f in files if not f.lower().endswith(skip_files_suffixes)
+                ]
+            data["files"] = files
         elif member.name.endswith("meta.yaml.template"):
             data["raw_recipe"] = _extract_read(tar, member, default="")
         elif member.name.endswith("meta.yaml"):

--- a/tests/test_info_json.py
+++ b/tests/test_info_json.py
@@ -77,3 +77,23 @@ def test_missing_conda_build_tar_bz2(backend: str):
     )
     assert info is not None
     assert info["conda_build_config"] == {}
+
+
+def test_files_skip_suffixes():
+    info = info_json.get_artifact_info_as_json(
+        "conda-forge",
+        "noarch",
+        "abipy-0.9.6-pyhd8ed1ab_0.conda",
+        backend="oci",
+    )
+    assert info is not None
+    assert "site-packages/abipy/__init__.py" in info["files"]
+    info = info_json.get_artifact_info_as_json(
+        "conda-forge",
+        "noarch",
+        "abipy-0.9.6-pyhd8ed1ab_0.conda",
+        backend="oci",
+        skip_files_suffixes=(".py",),
+    )
+    assert info is not None
+    assert "site-packages/abipy/__init__.py" not in info["files"]


### PR DESCRIPTION
Legacy behavior skipped pyc and txt files in the info json (I don't know why). I'd like to offer all files in the files-to-artifacts database so I'm offering a way to customize this.