### PR TITLE
add some repodata utilities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,4 +130,4 @@ dmypy.json
 conda_forge_metadata/_version.py
 
 # Downloaded stuff
-repodata_cache/
+.repodata_cache/

--- a/.gitignore
+++ b/.gitignore
@@ -128,3 +128,6 @@ dmypy.json
 # Pyre type checker
 .pyre/
 conda_forge_metadata/_version.py
+
+# Downloaded stuff
+repodata_cache/

--- a/conda_forge_metadata/repodata.py
+++ b/conda_forge_metadata/repodata.py
@@ -35,7 +35,8 @@ CACHE_DIR = Path(".repodata_cache")
 def all_labels(use_remote_cache: bool = False) -> List[str]:
     if use_remote_cache:
         r = requests.get(
-            "https://raw.githubusercontent.com/conda-forge/by-the-numbers/main/data/labels.json"
+            "https://raw.githubusercontent.com/conda-forge/"
+            "by-the-numbers/main/data/labels.json"
         )
         r.raise_for_status()
         return r.json()
@@ -48,9 +49,7 @@ def all_labels(use_remote_cache: bool = False) -> List[str]:
 
         return sorted(label for label in label_info if "/" not in label)
 
-    logger.info(
-        "No token detected. Fetching labels from anaconda.org HTML. Slow..."
-    )
+    logger.info("No token detected. Fetching labels from anaconda.org HTML. Slow...")
     r = requests.get("https://anaconda.org/conda-forge/repo")
     r.raise_for_status()
     html = r.text

--- a/conda_forge_metadata/repodata.py
+++ b/conda_forge_metadata/repodata.py
@@ -1,0 +1,75 @@
+"""
+Utilities to deal with repodata
+"""
+
+import bz2
+import json
+from logging import getLogger
+from pathlib import Path
+from typing import Iterable, List, Generator, Union, Dict, Any
+from urllib.request import urlretrieve
+
+logger = getLogger(__name__)
+
+SUBDIRS = (
+    "linux-64",
+    "osx-64",
+    "win-64",
+    "linux-aarch64",
+    "linux-ppc64le",
+    "osx-arm64",
+)
+CACHE_DIR = Path("repodata_cache")
+
+
+def fetch_repodata(
+    subdirs: Iterable[str] = SUBDIRS,
+    force_download: bool = False,
+    cache_dir: Union[str, Path] = CACHE_DIR,
+) -> List[Path]:
+    assert all(subdir in SUBDIRS for subdir in subdirs)
+    paths = []
+    for subdir in subdirs:
+        repodata = f"https://conda.anaconda.org/conda-forge/{subdir}/repodata.json"
+        local_fn = Path(cache_dir, f"{subdir}.json")
+        local_fn_bz2 = Path(cache_dir, f"{subdir}.json.bz2")
+        paths.append(local_fn)
+        if force_download or not local_fn.exists():
+            logger.info(f"Downloading {repodata} to {local_fn}")
+            local_fn.parent.mkdir(parents=True, exist_ok=True)
+            # Download the file
+            urlretrieve(f"{repodata}.bz2", local_fn_bz2)
+            with open(local_fn_bz2, "rb") as compressed, open(local_fn, "wb") as f:
+                f.write(bz2.decompress(compressed.read()))
+            local_fn_bz2.unlink()
+    return paths
+
+
+def list_artifacts(
+    repodata_jsons: Iterable[Union[str, Path]],
+    include_broken: bool = True,
+) -> Generator[str, None, None]:
+    for repodata in sorted(repodata_jsons):
+        repodata = Path(repodata)
+        subdir = repodata.stem
+        data = json.loads(repodata.read_text())
+        keys = ["packages", "packages.conda"]
+        if include_broken:
+            keys.append("removed")
+        for key in keys:
+            for pkg in data[key]:
+                yield f"{subdir}/{pkg}"
+
+
+def repodata(subdir: str) -> Dict[str, Any]:
+    assert subdir in SUBDIRS
+    path = fetch_repodata(subdirs=(subdir,))[0]
+    return json.loads(path.read_text())
+
+
+def n_artifacts() -> int:
+    repodatas = fetch_repodata()
+    count = 0
+    for _ in list_artifacts(repodatas):
+        count += 1
+    return count

--- a/conda_forge_metadata/repodata.py
+++ b/conda_forge_metadata/repodata.py
@@ -13,11 +13,12 @@ logger = getLogger(__name__)
 
 SUBDIRS = (
     "linux-64",
-    "osx-64",
-    "win-64",
     "linux-aarch64",
     "linux-ppc64le",
+    "osx-64",
     "osx-arm64",
+    "win-64",
+    "win-arm64"
     "noarch",
 )
 CACHE_DIR = Path(".repodata_cache")

--- a/conda_forge_metadata/repodata.py
+++ b/conda_forge_metadata/repodata.py
@@ -13,8 +13,8 @@ from pathlib import Path
 from typing import Any, Dict, Generator, Iterable, List, Union
 from urllib.request import urlretrieve
 
-import requests
 import bs4
+import requests
 
 logger = getLogger(__name__)
 
@@ -30,21 +30,20 @@ SUBDIRS = (
 )
 CACHE_DIR = Path(".repodata_cache")
 
-@lru_cache()
+
+@lru_cache
 def all_labels():
     if token := os.environ.get("BINSTAR_TOKEN"):
         label_info = requests.get(
             "https://api.anaconda.org/channels/conda-forge",
-            headers={'Authorization': f'token {token}'}
+            headers={"Authorization": f"token {token}"},
         ).json()
 
-        return sorted(
-            label
-            for label in label_info
-            if "/" not in label
-        )
+        return sorted(label for label in label_info if "/" not in label)
     else:
-        logger.info("No token detected. Fetching labels from anaconda.org HTML. Slow...")
+        logger.info(
+            "No token detected. Fetching labels from anaconda.org HTML. Slow..."
+        )
         r = requests.get("https://anaconda.org/conda-forge/repo")
         r.raise_for_status()
         html = r.text
@@ -98,7 +97,9 @@ def list_artifacts(
     for repodata in sorted(repodata_jsons):
         repodata = Path(repodata)
         subdir = repodata.stem.split(".")[0]
-        assert subdir in SUBDIRS, "Invalid repodata file name. Must be '<subdir>.<label>.json'."
+        assert (
+            subdir in SUBDIRS
+        ), "Invalid repodata file name. Must be '<subdir>.<label>.json'."
         data = json.loads(repodata.read_text())
         keys = ["packages", "packages.conda"]
         if include_broken:
@@ -137,4 +138,3 @@ def n_artifacts(include_all_labels: bool = True) -> int:
             seen.update(list_artifacts(repodatas, include_broken=True))
 
     return len(seen)
-

--- a/conda_forge_metadata/repodata.py
+++ b/conda_forge_metadata/repodata.py
@@ -10,7 +10,7 @@ from functools import lru_cache
 from itertools import product
 from logging import getLogger
 from pathlib import Path
-from typing import Any, Dict, Generator, Iterable, List, Union
+from typing import Any, Dict, Generator, Iterable, List, Tuple, Union
 from urllib.request import urlretrieve
 
 import bs4
@@ -121,18 +121,17 @@ def repodata(subdir: str) -> Dict[str, Any]:
     return json.loads(path.read_text())
 
 
-def n_artifacts(include_all_labels: bool = True) -> int:
+def n_artifacts(labels: Tuple[str] = ("main",)) -> int:
     """
-    This can be very slow if include_all_labels is true
+    To get _all_ artifacts ever published, use `n_artifacts(all_labels())`.
     """
-    if not include_all_labels:
+    if len(labels) == 1:
         count = 0
-        repodatas = fetch_repodata()
+        repodatas = fetch_repodata(label=labels[0])
         for _ in list_artifacts(repodatas):
             count += 1
         return count
 
-    labels = all_labels(use_remote_cache=True)
     seen = set()
     futures = []
     with ThreadPoolExecutor(max_workers=10) as executor:

--- a/conda_forge_metadata/repodata.py
+++ b/conda_forge_metadata/repodata.py
@@ -121,16 +121,12 @@ def repodata(subdir: str) -> Dict[str, Any]:
     return json.loads(path.read_text())
 
 
-def n_artifacts(labels: Tuple[str] = ("main",)) -> Tuple[int, int]:
+def n_artifacts(labels: Iterable[str] = ("main",)) -> Tuple[int, int]:
     """
     To get _all_ artifacts ever published, use `n_artifacts(all_labels())`.
 
     Returns number of artifacts and number of unique package names.
     """
-    def pkg_name(artifact: str) -> str:
-        _, pkg = artifact.split("/")
-        return pkg.rsplit("-", 2)[0]
-
     seen_artifacts, seen_package_names = set(), set()
     futures = []
     with ThreadPoolExecutor(max_workers=10) as executor:
@@ -141,7 +137,7 @@ def n_artifacts(labels: Tuple[str] = ("main",)) -> Tuple[int, int]:
             repodatas = future.result()
             artifacts = list_artifacts(repodatas, include_broken=True)
             for artifact in artifacts:
-                seen_artifacts.add(artifacts)
-                seen_package_names.add(pkg_name(artifact))
+                seen_artifacts.add(artifact)
+                seen_package_names.add(artifact.split("/")[-1].rsplit("-", 2)[0])
 
     return len(seen_artifacts), len(seen_package_names)

--- a/conda_forge_metadata/repodata.py
+++ b/conda_forge_metadata/repodata.py
@@ -18,7 +18,7 @@ SUBDIRS = (
     "osx-64",
     "osx-arm64",
     "win-64",
-    "win-arm64"
+    "win-arm64",
     "noarch",
 )
 CACHE_DIR = Path(".repodata_cache")
@@ -37,7 +37,10 @@ def fetch_repodata(
             repodata = f"https://conda.anaconda.org/conda-forge/{subdir}/repodata.json"
             local_fn = Path(cache_dir, f"{subdir}.json")
         else:
-            repodata = f"https://conda.anaconda.org/conda-forge/label/{label}/{subdir}/repodata.json"
+            repodata = (
+                "https://conda.anaconda.org/conda-forge/"
+                f"label/{label}/{subdir}/repodata.json"
+            )
             local_fn = Path(cache_dir, f"{subdir}.{label}.json")
         local_fn_bz2 = Path(str(local_fn) + ".bz2")
         paths.append(local_fn)

--- a/conda_forge_metadata/repodata.py
+++ b/conda_forge_metadata/repodata.py
@@ -6,7 +6,7 @@ import bz2
 import json
 from logging import getLogger
 from pathlib import Path
-from typing import Iterable, List, Generator, Union, Dict, Any
+from typing import Any, Dict, Generator, Iterable, List, Union
 from urllib.request import urlretrieve
 
 logger = getLogger(__name__)

--- a/conda_forge_metadata/repodata.py
+++ b/conda_forge_metadata/repodata.py
@@ -132,7 +132,7 @@ def n_artifacts(include_all_labels: bool = True) -> int:
             count += 1
         return count
 
-    labels = all_labels()
+    labels = all_labels(use_remote_cache=True)
     seen = set()
     futures = []
     with ThreadPoolExecutor(max_workers=10) as executor:

--- a/conda_forge_metadata/repodata.py
+++ b/conda_forge_metadata/repodata.py
@@ -19,7 +19,7 @@ SUBDIRS = (
     "linux-ppc64le",
     "osx-arm64",
 )
-CACHE_DIR = Path("repodata_cache")
+CACHE_DIR = Path(".repodata_cache")
 
 
 def fetch_repodata(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,8 @@ dependencies = [
     "deprecated",
     "requests",
     "ruamel.yaml",
-    "typing-extensions"
+    "typing-extensions",
+    "beautifulsoup4"
 ]
 license = {file = "LICENSE"}
 readme = "README.md"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
 flake8
 flaky
 pip
-pytest
+pytest <8.1.0a0  # flaky does not support pytest >=8.1
 python-build
 setuptools>=45
 setuptools_scm>=7

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
+beautifulsoup4
 conda-oci-mirror
 deprecated
 requests
 ruamel.yaml
 typing-extensions
-beautifulsoup4

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ deprecated
 requests
 ruamel.yaml
 typing-extensions
+beautifulsoup4

--- a/tests/test_repodata.py
+++ b/tests/test_repodata.py
@@ -1,0 +1,9 @@
+from conda_forge_metadata import repodata
+
+
+def test_labels_anaconda_org(monkeypatch): # type: ignore
+    monkeypatch.delenv("BINSTAR_TOKEN", raising=False)
+    labels = repodata.all_labels()
+    assert len(labels) >= 20
+    assert "main" in labels
+    assert "broken" in labels

--- a/tests/test_repodata.py
+++ b/tests/test_repodata.py
@@ -1,7 +1,7 @@
 from conda_forge_metadata import repodata
 
 
-def test_labels_anaconda_org(monkeypatch): # type: ignore
+def test_labels_anaconda_org(monkeypatch):  # type: ignore
     monkeypatch.delenv("BINSTAR_TOKEN", raising=False)
     labels = repodata.all_labels()
     assert len(labels) >= 20


### PR DESCRIPTION
I noticed that `conda-forge/by-the-numbers` was relying on the now deprecated libcfgraph functions, so this is an alternative implementation to get the number of published artifacts.