### PR TITLE
Use `pathlib` to parse `info/` paths in a stricter way

### DIFF
--- a/conda_forge_metadata/artifact_info/info_json.py
+++ b/conda_forge_metadata/artifact_info/info_json.py
@@ -116,9 +116,9 @@ def info_json_from_tar_generator(
     YAML.allow_duplicate_keys = True
     for tar, member in tar_tuples:
         path = Path(member.name)
-        if path.parts[0] != "info":
-            continue
-        if path.parts[1] in ("test", "license"):
+        if len(path.parts) > 1 and path.parts[0] == "info":
+            path = Path(*path.parts[1:])
+        if path.parts and path.parts[0] in ("test", "licenses"):
             continue
         if path.name == "index.json":
             index = json.loads(_extract_read(tar, member, default="{}"))

--- a/conda_forge_metadata/artifact_info/info_json.py
+++ b/conda_forge_metadata/artifact_info/info_json.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import tarfile
 import warnings
+from pathlib import Path
 from typing import Any, Generator, Tuple
 
 from ruamel import yaml
@@ -114,27 +115,32 @@ def info_json_from_tar_generator(
     # e.g. linux-64/clangxx_osx-64-16.0.6-h027b494_6.conda
     YAML.allow_duplicate_keys = True
     for tar, member in tar_tuples:
-        if member.name.endswith("index.json"):
+        path = Path(member.name)
+        if path.parts[0] != "info":
+            continue
+        if path.parts[1] in ("test", "license"):
+            continue
+        if path.name == "index.json":
             index = json.loads(_extract_read(tar, member, default="{}"))
             data["name"] = index.get("name", "")
             data["version"] = index.get("version", "")
             data["index"] = index
-        elif member.name.endswith("about.json"):
+        elif path.name == "about.json":
             data["about"] = json.loads(_extract_read(tar, member, default="{}"))
-        elif member.name.endswith("conda_build_config.yaml"):
+        elif path.name == "conda_build_config.yaml":
             data["conda_build_config"] = YAML.load(
                 _extract_read(tar, member, default="{}")
             )
-        elif member.name.endswith("files"):
+        elif path.name == "files":
             files = _extract_read(tar, member, default="").splitlines()
             if skip_files_suffixes:
                 files = [
                     f for f in files if not f.lower().endswith(skip_files_suffixes)
                 ]
             data["files"] = files
-        elif member.name.endswith("meta.yaml.template"):
+        elif path.name == "meta.yaml.template":
             data["raw_recipe"] = _extract_read(tar, member, default="")
-        elif member.name.endswith("meta.yaml"):
+        elif path.name == "meta.yaml":
             x = _extract_read(tar, member, default="{}")
             if ("{{" in x or "{%" in x) and not data["raw_recipe"]:
                 data["raw_recipe"] = x

--- a/tests/test_info_json.py
+++ b/tests/test_info_json.py
@@ -65,6 +65,30 @@ def test_info_json_conda(backend: str):
 
 
 @pytest.mark.parametrize("backend", info_json.VALID_BACKENDS)
+def test_info_json_conda_unlucky_test_file(backend: str):
+    """
+    See https://github.com/regro/conda-forge-metadata/pull/36
+
+    This artifact has test/xxxx/something_index.json,
+    which tripped the original info/ parsing logic.
+    """
+    info = info_json.get_artifact_info_as_json(
+        "conda-forge",
+        "noarch",
+        "nodeenv-1.9.1-pyhd8ed1ab_0.conda",
+        backend=backend,
+    )
+    assert info is not None
+    assert info["metadata_version"] == 1
+    assert info["name"] == "nodeenv"
+    assert info["version"] == "1.9.1"
+    assert info["index"]["name"] == "nodeenv"
+    assert info["index"]["version"] == "1.9.1"
+    assert info["index"]["build"] == "pyhd8ed1ab_0"
+    assert info["index"]["subdir"] == "noarch"
+
+
+@pytest.mark.parametrize("backend", info_json.VALID_BACKENDS)
 def test_missing_conda_build_tar_bz2(backend: str):
     if backend == "streamed":
         pytest.xfail("streamed backend does not support .tar.bz2 artifacts")


### PR DESCRIPTION
The current logic in `info_json_from_tar_generator` is a bit too lax so after processing thousands of artifacts we got unlucky with https://conda-metadata-app.streamlit.app/?q=conda-forge%2Fnoarch%2Fnodeenv-1.9.1-pyhd8ed1ab_0.conda because it happens to contain a JSON file under the tests files that ends up in `index.json` and it's parsed as part of the conda metadata incorrectly. This makes this code a bit stricter.