### PR TITLE
Add `repodata.aggregated()` to compute sums of different items across all repodatas

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,6 @@ conda_forge_metadata/_version.py
 
 # Downloaded stuff
 .repodata_cache/
+
+# uv
+uv.lock

--- a/conda_forge_metadata/repodata.py
+++ b/conda_forge_metadata/repodata.py
@@ -97,7 +97,7 @@ def fetch_repodata(
     return paths
 
 
-def iter_repodatas(
+def _iter_repodatas(
     repodata_jsons: Iterable[str | Path],
     include_broken: bool = True,
 ) -> Iterable[tuple[str, str, str, dict[str, object]]]:
@@ -125,12 +125,7 @@ def list_artifacts(
     repodata_jsons: Iterable[str | Path],
     include_broken: bool = True,
 ) -> Iterable[str]:
-    """
-    Deprecated.
-
-    Use iter_repodatas() and join the 2nd and 3rd items of each tuple.
-    """
-    for _, subdir, fn, _ in iter_repodatas(
+    for _, subdir, fn, _ in _iter_repodatas(
         repodata_jsons=repodata_jsons, include_broken=include_broken
     ):
         yield f"{subdir}/{fn}"
@@ -169,9 +164,13 @@ def aggregated(
             futures.append(future)
         for future in as_completed(futures):
             repodatas = future.result()
-            for label, subdir, fn, record in iter_repodatas(repodatas, include_broken=True):
+            for label, subdir, fn, record in _iter_repodatas(
+                repodatas, include_broken=True
+            ):
                 if with_artifacts:
-                    seen_artifacts.add(f"{label}/{subdir}/{fn}/{record.get('sha256') or record.get('md5')}")
+                    seen_artifacts.add(
+                        f"{label}/{subdir}/{fn}/{record.get('sha256') or record.get('md5')}"
+                    )
                 if with_names:
                     seen_names.add(record["name"])
                 if with_size:

--- a/conda_forge_metadata/repodata.py
+++ b/conda_forge_metadata/repodata.py
@@ -100,10 +100,15 @@ def fetch_repodata(
 def iter_repodatas(
     repodata_jsons: Iterable[str | Path],
     include_broken: bool = True,
-) -> Iterable[tuple[str, str, dict[str, object]]]:
+) -> Iterable[tuple[str, str, str, dict[str, object]]]:
+    """
+    Repodata JSON filenames MUST be `{subdir}.{label}.json`.
+
+    Yields label, subdir, filename, record tuples
+    """
     for repodata in sorted(repodata_jsons):
         repodata = Path(repodata)
-        subdir = repodata.stem.split(".")[0]
+        subdir, label, *_ = repodata.stem.split(".")
         assert subdir in SUBDIRS, (
             "Invalid repodata file name. Must be '<subdir>.<label>.json'."
         )
@@ -113,7 +118,7 @@ def iter_repodatas(
             keys.append("removed")
         for key in keys:
             for fn, record in data.get(key, {}).items():
-                yield subdir, fn, record
+                yield label, subdir, fn, record
 
 
 def list_artifacts(
@@ -123,9 +128,9 @@ def list_artifacts(
     """
     Deprecated.
 
-    Use iter_repodatas() and join the first two items of each tuple.
+    Use iter_repodatas() and join the 2nd and 3rd items of each tuple.
     """
-    for subdir, fn, _ in iter_repodatas(
+    for _, subdir, fn, _ in iter_repodatas(
         repodata_jsons=repodata_jsons, include_broken=include_broken
     ):
         yield f"{subdir}/{fn}"
@@ -164,9 +169,9 @@ def aggregated(
             futures.append(future)
         for future in as_completed(futures):
             repodatas = future.result()
-            for subdir, fn, record in iter_repodatas(repodatas, include_broken=True):
+            for label, subdir, fn, record in iter_repodatas(repodatas, include_broken=True):
                 if with_artifacts:
-                    seen_artifacts.add(f"{subdir}/{fn}")
+                    seen_artifacts.add(f"{label}/{subdir}/{fn}/{record.get('sha256') or record.get('md5')}")
                 if with_names:
                     seen_names.add(record["name"])
                 if with_size:

--- a/conda_forge_metadata/repodata.py
+++ b/conda_forge_metadata/repodata.py
@@ -125,7 +125,7 @@ def repodata(subdir: str) -> dict[str, Any]:
 
 def n_artifacts(labels: Iterable[str] = ("main",)) -> tuple[int, int]:
     """
-    Deprecated.
+    Deprecated. Use `aggregated(reports=["artifacts", "names"]).values()`.
 
     To get _all_ artifacts ever published, use `n_artifacts(all_labels())`.
 

--- a/conda_forge_metadata/repodata.py
+++ b/conda_forge_metadata/repodata.py
@@ -1,15 +1,17 @@
 """Utilities to deal with repodata"""
 
+from __future__ import annotations
+
 import bz2
 import json
 import os
-from collections.abc import Generator, Iterable
+from collections.abc import Iterable
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from functools import lru_cache
 from itertools import product
 from logging import getLogger
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 from urllib.request import urlretrieve
 
 import bs4
@@ -95,10 +97,10 @@ def fetch_repodata(
     return paths
 
 
-def list_artifacts(
+def iter_repodatas(
     repodata_jsons: Iterable[str | Path],
     include_broken: bool = True,
-) -> Generator[str, None, None]:
+) -> Iterable[tuple[str, str, dict[str, object]]]:
     for repodata in sorted(repodata_jsons):
         repodata = Path(repodata)
         subdir = repodata.stem.split(".")[0]
@@ -110,8 +112,23 @@ def list_artifacts(
         if include_broken:
             keys.append("removed")
         for key in keys:
-            for pkg in data.get(key, ()):
-                yield f"{subdir}/{pkg}"
+            for fn, record in data.get(key, {}).items():
+                yield subdir, fn, record
+
+
+def list_artifacts(
+    repodata_jsons: Iterable[str | Path],
+    include_broken: bool = True,
+) -> Iterable[str]:
+    """
+    Deprecated.
+
+    Use iter_repodatas() and join the first two items of each tuple.
+    """
+    for subdir, fn, _ in iter_repodatas(
+        repodata_jsons=repodata_jsons, include_broken=include_broken
+    ):
+        yield f"{subdir}/{fn}"
 
 
 def repodata(subdir: str) -> dict[str, Any]:
@@ -121,11 +138,25 @@ def repodata(subdir: str) -> dict[str, Any]:
 
 
 def n_artifacts(labels: Iterable[str] = ("main",)) -> tuple[int, int]:
-    """To get _all_ artifacts ever published, use `n_artifacts(all_labels())`.
+    """
+    Deprecated.
+
+    To get _all_ artifacts ever published, use `n_artifacts(all_labels())`.
 
     Returns number of artifacts and number of unique package names.
     """
-    seen_artifacts, seen_package_names = set(), set()
+    result = aggregated(reports=["artifacts", "names"], labels=labels)
+    return result["artifacts"], result["names"]
+
+
+def aggregated(
+    reports: Iterable[Literal["artifacts", "names", "size"]],
+    labels: Iterable[str] = ("main",),
+) -> dict[str, int]:
+    with_artifacts = "artifacts" in reports
+    with_names = "names" in reports
+    with_size = "size" in reports
+    seen_artifacts, seen_names, size = set(), set(), 0
     futures = []
     with ThreadPoolExecutor(max_workers=10) as executor:
         for label, subdir in product(labels, SUBDIRS):
@@ -133,9 +164,20 @@ def n_artifacts(labels: Iterable[str] = ("main",)) -> tuple[int, int]:
             futures.append(future)
         for future in as_completed(futures):
             repodatas = future.result()
-            artifacts = list_artifacts(repodatas, include_broken=True)
-            for artifact in artifacts:
-                seen_artifacts.add(artifact)
-                seen_package_names.add(artifact.split("/")[-1].rsplit("-", 2)[0])
+            for subdir, fn, record in iter_repodatas(repodatas, include_broken=True):
+                if with_artifacts:
+                    seen_artifacts.add(f"{subdir}/{fn}")
+                if with_names:
+                    seen_names.add(record["name"])
+                if with_size:
+                    size += record.get("size") or 0  # type: ignore
 
-    return len(seen_artifacts), len(seen_package_names)
+    result: dict[str, int] = {}
+    if with_artifacts:
+        result["artifacts"] = len(seen_artifacts)
+    if with_names:
+        result["names"] = len(seen_names)
+    if with_size:
+        result["size"] = size
+
+    return result

--- a/tests/test_repodata.py
+++ b/tests/test_repodata.py
@@ -12,3 +12,11 @@ def test_labels_anaconda_org(monkeypatch):  # type: ignore
     assert len(labels) >= 20
     assert "main" in labels
     assert "broken" in labels
+
+
+def test_aggregated():
+    reports = ["artifacts", "names", "size"]
+    result = repodata.aggregated(reports=reports, labels=("hsp2_dev",))  # type: ignore
+    assert reports == list(result.keys())
+    for key, value in result.items():
+        assert value > 0, f"{key}={value}"


### PR DESCRIPTION
`aggregated()` currently supports:

- Number of unique artifacts
- Number of unique package names
- Total size in bytes

Supersedes `n_artifacts()`. A new private helper `_iter_repodatas()` returns `label, subdir, filename, record` tuples.