### PR TITLE
Remove broken HTML fallback in all_labels()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,6 @@ conda_forge_metadata/_version.py
 
 # Downloaded stuff
 .repodata_cache/
+
+# uv
+uv.lock

--- a/conda_forge_metadata/repodata.py
+++ b/conda_forge_metadata/repodata.py
@@ -12,7 +12,6 @@ from pathlib import Path
 from typing import Any
 from urllib.request import urlretrieve
 
-import bs4
 import requests
 
 logger = getLogger(__name__)
@@ -48,21 +47,8 @@ def all_labels(use_remote_cache: bool = False) -> list[str]:
 
         return sorted(label for label in label_info if "/" not in label)
 
-    logger.info("No token detected. Fetching labels from anaconda.org HTML. Slow...")
-    r = requests.get("https://anaconda.org/conda-forge/repo")
-    r.raise_for_status()
-    html = r.text
-    soup = bs4.BeautifulSoup(html, "html.parser")
-    labels = []
-    len_prefix = len("/conda-forge/repo?label=")
-    for element in soup.select("ul#Label > li > a"):
-        href = element.get("href")
-        if not href:
-            continue
-        label = href[len_prefix:]
-        if label and label not in ("all", "empty") and "/" not in label:
-            labels.append(label)
-    return sorted(labels)
+    logger.warning("Could not fetch all labels; returning 'main' only as a fallback")
+    return ["main"]
 
 
 def fetch_repodata(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,6 @@ dependencies = [
     "requests",
     "ruamel.yaml",
     "typing-extensions",
-    "beautifulsoup4",
     "conda-oci-mirror",
     "conda_package_streaming >=0.12.0"
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-beautifulsoup4
 conda-oci-mirror
 conda-package-streaming >=0.12.0
 deprecated


### PR DESCRIPTION
This doesn't work anymore, so let's remove it. Reported it to .org team in [#infrastructure > new Anaconda.org: how to list all labels of a channel?](https://conda.zulipchat.com/#narrow/channel/487124-infrastructure/topic/new.20Anaconda.2Eorg.3A.20how.20to.20list.20all.20labels.20of.20a.20channel.3F/with/600134847). The token method still works, though!