### PR TITLE
Fix: `removed` entries are a list (filenames only), no records

### DIFF
--- a/conda_forge_metadata/repodata.py
+++ b/conda_forge_metadata/repodata.py
@@ -90,7 +90,9 @@ def _iter_repodatas(
     """
     Repodata JSON filenames MUST be `{subdir}.{label}.json`.
 
-    Yields label, subdir, filename, record tuples
+    Yields label, subdir, filename, record tuples.
+
+    Note: When include_broken is True, some records may be empty.
     """
     for repodata in sorted(repodata_jsons):
         repodata = Path(repodata)
@@ -103,8 +105,12 @@ def _iter_repodatas(
         if include_broken:
             keys.append("removed")
         for key in keys:
-            for fn, record in data.get(key, {}).items():
-                yield label, subdir, fn, record
+            if key == "removed":
+                for fn in data.get(key, ()):
+                    yield label, subdir, fn, {}
+            else:
+                for fn, record in data.get(key, {}).items():
+                    yield label, subdir, fn, record
 
 
 def list_artifacts(
@@ -155,10 +161,10 @@ def aggregated(
             ):
                 if with_artifacts:
                     seen_artifacts.add(
-                        f"{label}/{subdir}/{fn}/{record.get('sha256') or record.get('md5')}"
+                        f"{label}/{subdir}/{fn}/{record.get('sha256') or record.get('md5') or ''}"
                     )
                 if with_names:
-                    seen_names.add(record["name"])
+                    seen_names.add(record.get("name") or fn.rsplit("-", 2)[0])
                 if with_size:
                     size += record.get("size") or 0  # type: ignore
 

--- a/conda_forge_metadata/repodata.py
+++ b/conda_forge_metadata/repodata.py
@@ -144,6 +144,7 @@ def n_artifacts(labels: Iterable[str] = ("main",)) -> tuple[int, int]:
 def aggregated(
     reports: Iterable[Literal["artifacts", "names", "size"]],
     labels: Iterable[str] = ("main",),
+    include_broken: bool = True,
 ) -> dict[str, int]:
     with_artifacts = "artifacts" in reports
     with_names = "names" in reports
@@ -157,7 +158,7 @@ def aggregated(
         for future in as_completed(futures):
             repodatas = future.result()
             for label, subdir, fn, record in _iter_repodatas(
-                repodatas, include_broken=True
+                repodatas, include_broken=include_broken
             ):
                 if with_artifacts:
                     seen_artifacts.add(

--- a/tests/test_repodata.py
+++ b/tests/test_repodata.py
@@ -1,3 +1,6 @@
+import json
+from pathlib import Path
+
 import pytest
 
 from conda_forge_metadata import repodata
@@ -14,9 +17,35 @@ def test_labels_anaconda_org(monkeypatch):  # type: ignore
     assert "broken" in labels
 
 
-def test_aggregated():
+@pytest.fixture
+def hsp2_dev_with_removed_cache(tmp_path: Path):
+    repodata.fetch_repodata(label="hsp2_dev", force_download=True, cache_dir=tmp_path)
+    noarch_json = tmp_path / "noarch.hsp2_dev.json"
+    if noarch_json.is_file():
+        noarch_repodata = json.loads(noarch_json.read_text())
+    else:
+        noarch_repodata = {"packages": {}, "packages.conda": {}, "removed": []}
+    noarch_repodata.setdefault("removed", []).append("removed-package-1-0")
+    noarch_json.write_text(json.dumps(noarch_repodata))
+    yield tmp_path
+
+
+def test_aggregated(hsp2_dev_with_removed_cache: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(repodata, "CACHE_DIR", hsp2_dev_with_removed_cache)
     reports = ["artifacts", "names", "size"]
-    result = repodata.aggregated(reports=reports, labels=("hsp2_dev",))  # type: ignore
+    result = repodata.aggregated(
+        reports=reports,  # type: ignore
+        labels=("hsp2_dev",),
+        include_broken=True,
+    )
     assert reports == list(result.keys())
     for key, value in result.items():
         assert value > 0, f"{key}={value}"
+
+    # Without the 'removed' entry, one less artifact
+    result2 = repodata.aggregated(
+        reports=reports,  # type: ignore
+        labels=("hsp2_dev",),
+        include_broken=False,
+    )
+    assert result["artifacts"] == (result2["artifacts"] + 1)


### PR DESCRIPTION
Small follow-up to #102